### PR TITLE
Add editing guardrails and deletion flows for pickings

### DIFF
--- a/lib/pickingStatus.ts
+++ b/lib/pickingStatus.ts
@@ -1,0 +1,48 @@
+import prisma from './prisma'
+
+export async function recalculatePickingState(pickingId: number) {
+  const picking = await prisma.pickings.findUnique({
+    where: { id: pickingId },
+    include: {
+      photos: true,
+      lines: { include: { photos: true } },
+    },
+  })
+
+  if (!picking) return null
+
+  const hasPackingPhoto = picking.photos.some(
+    (photo) => photo.photo_type === 'PACK' && photo.picking_line_id === null,
+  )
+
+  await Promise.all(
+    picking.lines.map(async (line) => {
+      const hasPickPhoto = line.photos.some((photo) => photo.photo_type === 'PICK')
+      const nextStatus = hasPickPhoto ? (hasPackingPhoto ? 'PACKED' : 'PICKED') : 'PENDING'
+
+      if (line.status !== nextStatus) {
+        await prisma.picking_lines.update({ where: { id: line.id }, data: { status: nextStatus } })
+      }
+    }),
+  )
+
+  const refreshedLineStatuses = await prisma.picking_lines.findMany({
+    where: { picking_id: pickingId },
+    select: { status: true },
+  })
+
+  const allPacked = refreshedLineStatuses.length > 0 && refreshedLineStatuses.every((line) => line.status === 'PACKED')
+  const anyPicked = refreshedLineStatuses.some((line) => line.status === 'PICKED' || line.status === 'PACKED')
+
+  const nextPickingStatus = allPacked
+    ? 'COMPLETED'
+    : hasPackingPhoto && anyPicked
+      ? 'PACKED'
+      : anyPicked
+        ? 'PICKED'
+        : 'IN_PROGRESS'
+
+  await prisma.pickings.update({ where: { id: pickingId }, data: { status: nextPickingStatus } })
+
+  return nextPickingStatus
+}

--- a/pages/api/picking/index.ts
+++ b/pages/api/picking/index.ts
@@ -35,17 +35,18 @@ function mapSapLine(item: any, idx: number, sapOrder: string) {
   }
 }
 
-type Method = 'GET' | 'POST'
+type Method = 'GET' | 'POST' | 'DELETE'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const method = req.method as Method
 
-  if (!['GET', 'POST'].includes(method)) {
+  if (!['GET', 'POST', 'DELETE'].includes(method)) {
     return res.status(405).json({ message: 'Method not allowed' })
   }
 
   if (method === 'GET') return listPickings(req, res)
-  return createPicking(req, res)
+  if (method === 'POST') return createPicking(req, res)
+  return deletePicking(req, res)
 }
 
 async function listPickings(req: NextApiRequest, res: NextApiResponse) {
@@ -160,5 +161,29 @@ async function createPicking(req: NextApiRequest, res: NextApiResponse) {
   } catch (error) {
     console.error('create picking error', error)
     return res.status(500).json({ message: 'Error creando picking' })
+  }
+}
+
+async function deletePicking(req: NextApiRequest, res: NextApiResponse) {
+  const { pickingId } = req.body as { pickingId?: number }
+
+  if (!pickingId) return res.status(400).json({ message: 'pickingId es requerido' })
+
+  try {
+    const picking = await prisma.pickings.findUnique({ where: { id: Number(pickingId) } })
+
+    if (!picking) return res.status(404).json({ message: 'Picking no encontrado' })
+    if (picking.status === 'COMPLETED') {
+      return res.status(400).json({ message: 'No se puede eliminar un picking completado' })
+    }
+
+    await prisma.picking_photos.deleteMany({ where: { picking_id: picking.id } })
+    await prisma.picking_lines.deleteMany({ where: { picking_id: picking.id } })
+    await prisma.pickings.delete({ where: { id: picking.id } })
+
+    return res.status(200).json({ message: 'Picking eliminado' })
+  } catch (error) {
+    console.error('delete picking error', error)
+    return res.status(500).json({ message: 'No se pudo eliminar el picking' })
   }
 }

--- a/pages/api/picking/line.ts
+++ b/pages/api/picking/line.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import prisma from '@/lib/prisma'
+import { recalculatePickingState } from '@/lib/pickingStatus'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'DELETE') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  const { lineId } = req.body as { lineId?: number }
+
+  if (!lineId) return res.status(400).json({ message: 'lineId es requerido' })
+
+  try {
+    const line = await prisma.picking_lines.findUnique({
+      where: { id: Number(lineId) },
+      include: { picking: true },
+    })
+
+    if (!line || !line.picking) {
+      return res.status(404).json({ message: 'Línea o picking no encontrado' })
+    }
+
+    if (line.picking.status === 'COMPLETED') {
+      return res.status(400).json({ message: 'No se puede eliminar una línea de un picking completado' })
+    }
+
+    await prisma.picking_photos.deleteMany({ where: { picking_line_id: line.id } })
+    await prisma.picking_lines.delete({ where: { id: line.id } })
+
+    await recalculatePickingState(line.picking_id ?? line.picking.id)
+
+    return res.status(200).json({ message: 'Línea eliminada' })
+  } catch (error) {
+    console.error('delete picking line error', error)
+    return res.status(500).json({ message: 'No se pudo eliminar la línea' })
+  }
+}

--- a/pages/api/picking/photo.ts
+++ b/pages/api/picking/photo.ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import prisma from '@/lib/prisma'
+import { recalculatePickingState } from '@/lib/pickingStatus'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
+  if (!['POST', 'PUT', 'DELETE'].includes(req.method || '')) {
     return res.status(405).json({ message: 'Method not allowed' })
   }
 
@@ -15,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   const userId = providedUserId ? Number(providedUserId) : null
 
-  if (!photoType || !s3Url) {
+  if (req.method !== 'DELETE' && (!photoType || !s3Url)) {
     return res.status(400).json({ message: 'Datos incompletos' })
   }
 
@@ -26,6 +27,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     let targetPickingId: number | null = null
     let targetLineId: number | null = null
+
+    const ensureNotCompleted = async (id: number) => {
+      const current = await prisma.pickings.findUnique({ where: { id }, select: { status: true } })
+      if (current?.status === 'COMPLETED') {
+        throw new Error('El picking está completado y no permite cambios')
+      }
+    }
 
     if (photoType === 'PICK') {
       if (!pickingLineId) return res.status(400).json({ message: 'pickingLineId es requerido para foto de picking' })
@@ -39,27 +47,43 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(404).json({ message: 'Línea o picking no encontrado' })
       }
 
+      await ensureNotCompleted(line.picking_id || line.picking.id)
+
       targetPickingId = line.picking_id
       targetLineId = line.id
 
-      await prisma.picking_photos.create({
-        data: {
-          picking_line_id: line.id,
-          picking_id: line.picking_id,
-          photo_type: photoType,
-          s3_url: s3Url,
-          uploaded_by_user_id: userId ?? undefined,
-        },
-      })
+      if (req.method === 'DELETE') {
+        const latestPhoto = await prisma.picking_photos.findFirst({
+          where: { picking_line_id: line.id, photo_type: 'PICK' },
+          orderBy: { uploaded_at: 'desc' },
+        })
 
-      const photos = await prisma.picking_photos.findMany({ where: { picking_line_id: line.id } })
-      const hasPick = photos.some((p) => p.photo_type === 'PICK')
-      const newStatus = hasPick ? 'PICKED' : 'PENDING'
+        if (!latestPhoto) return res.status(404).json({ message: 'No hay foto para eliminar' })
 
-      await prisma.picking_lines.update({
-        where: { id: line.id },
-        data: { status: newStatus },
-      })
+        await prisma.picking_photos.delete({ where: { id: latestPhoto.id } })
+      } else if (req.method === 'PUT') {
+        const latestPhoto = await prisma.picking_photos.findFirst({
+          where: { picking_line_id: line.id, photo_type: 'PICK' },
+          orderBy: { uploaded_at: 'desc' },
+        })
+
+        if (!latestPhoto) return res.status(404).json({ message: 'No hay foto previa para reemplazar' })
+
+        await prisma.picking_photos.update({
+          where: { id: latestPhoto.id },
+          data: { s3_url: s3Url as string, uploaded_by_user_id: userId ?? undefined },
+        })
+      } else {
+        await prisma.picking_photos.create({
+          data: {
+            picking_line_id: line.id,
+            picking_id: line.picking_id,
+            photo_type: photoType,
+            s3_url: s3Url,
+            uploaded_by_user_id: userId ?? undefined,
+          },
+        })
+      }
     } else {
       if (!pickingId && !pickingLineId) {
         return res.status(400).json({ message: 'Debe enviar pickingId para foto de embalaje' })
@@ -78,47 +102,53 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(404).json({ message: 'Picking no encontrado' })
       }
 
+      await ensureNotCompleted(picking.id)
+
       targetPickingId = picking.id
 
-      await prisma.picking_photos.create({
-        data: {
-          picking_id: picking.id,
-          picking_line_id: pickingLineId ? Number(pickingLineId) : null,
-          photo_type: 'PACK',
-          s3_url: s3Url,
-          uploaded_by_user_id: userId ?? undefined,
-        },
-      })
+      if (req.method === 'DELETE') {
+        const packPhoto = await prisma.picking_photos.findFirst({
+          where: { picking_id: picking.id, picking_line_id: null, photo_type: 'PACK' },
+          orderBy: { uploaded_at: 'desc' },
+        })
 
-      // Marcar líneas como PACKED solo cuando ya tienen evidencia de picking
-      const pickedLineIds = picking.lines
-        .filter((line) => line.photos?.some((p) => p.photo_type === 'PICK'))
-        .map((line) => line.id)
+        if (!packPhoto) return res.status(404).json({ message: 'No hay foto de embalaje para eliminar' })
 
-      if (pickedLineIds.length) {
-        await prisma.picking_lines.updateMany({ where: { id: { in: pickedLineIds } }, data: { status: 'PACKED' } })
+        await prisma.picking_photos.delete({ where: { id: packPhoto.id } })
+      } else if (req.method === 'PUT') {
+        const packPhoto = await prisma.picking_photos.findFirst({
+          where: { picking_id: picking.id, picking_line_id: null, photo_type: 'PACK' },
+          orderBy: { uploaded_at: 'desc' },
+        })
+
+        if (!packPhoto) return res.status(404).json({ message: 'No hay foto de embalaje previa para reemplazar' })
+
+        await prisma.picking_photos.update({
+          where: { id: packPhoto.id },
+          data: { s3_url: s3Url as string, uploaded_by_user_id: userId ?? undefined },
+        })
+      } else {
+        await prisma.picking_photos.create({
+          data: {
+            picking_id: picking.id,
+            picking_line_id: pickingLineId ? Number(pickingLineId) : null,
+            photo_type: 'PACK',
+            s3_url: s3Url,
+            uploaded_by_user_id: userId ?? undefined,
+          },
+        })
       }
     }
 
     if (!targetPickingId) return res.status(500).json({ message: 'No se pudo determinar picking' })
 
-    const lineStatuses = await prisma.picking_lines.findMany({
-      where: { picking_id: targetPickingId },
-      select: { id: true, status: true },
-    })
-
-    const allPacked = lineStatuses.every((l) => l.status === 'PACKED')
-    const anyPick = photoType === 'PACK' || lineStatuses.some((l) => l.status === 'PICKED' || l.status === 'PACKED')
-    const pickingStatus = allPacked ? 'COMPLETED' : anyPick ? 'PACKED' : 'IN_PROGRESS'
-
-    await prisma.pickings.update({
-      where: { id: targetPickingId },
-      data: { status: pickingStatus },
-    })
+    const pickingStatus = await recalculatePickingState(targetPickingId)
 
     return res.status(200).json({ url: s3Url, pickingStatus, lineId: targetLineId })
   } catch (error) {
     console.error('photo upload error', error)
-    return res.status(500).json({ message: 'Error subiendo foto' })
+    const message = error instanceof Error ? error.message : 'Error subiendo foto'
+    const code = message.includes('completado') ? 400 : 500
+    return res.status(code).json({ message })
   }
 }

--- a/pages/picking.tsx
+++ b/pages/picking.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type React from 'react'
 import Head from 'next/head'
-import { Camera, CheckCircle, Image as ImageIcon, Loader2, PackageCheck, Search, Upload, X } from 'lucide-react'
+import { Camera, CheckCircle, Image as ImageIcon, Loader2, PackageCheck, Search, Trash2, Upload, X } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 
 import { format } from 'date-fns'
@@ -63,13 +63,18 @@ export default function PickingDashboard() {
   const [filters, setFilters] = useState({ status: '', sapOrder: '' })
   const [feedback, setFeedback] = useState<string | null>(null)
   const [uploadContext, setUploadContext] = useState<
-    { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string }
-  | null>(null)
+    { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string; action?: 'create' | 'replace' }
+    | null>(null)
   const [selectedPicking, setSelectedPicking] = useState<Picking | null>(null)
   const [previewPhoto, setPreviewPhoto] = useState<{ url: string; title: string } | null>(null)
   const [cameraCapture, setCameraCapture] = useState<
-    { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string }
-  | null>(null)
+    { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string; action?: 'create' | 'replace' }
+    | null>(null)
+  const [uploading, setUploading] = useState(false)
+  const [completing, setCompleting] = useState(false)
+  const [deletingLineId, setDeletingLineId] = useState<number | null>(null)
+  const [deletingPhotoKey, setDeletingPhotoKey] = useState<string | null>(null)
+  const [deletingPickingId, setDeletingPickingId] = useState<number | null>(null)
 
   const galleryInputRef = useRef<HTMLInputElement | null>(null)
   const cameraInputRef = useRef<HTMLInputElement | null>(null)
@@ -136,12 +141,30 @@ export default function PickingDashboard() {
     }
   }
 
+  const refreshPickingData = async (sapOrderOverride?: string) => {
+    const sapOrder = sapOrderOverride || picking?.sap_order_id || orderData?.sapOrder || search.trim()
+    if (!sapOrder) return
+
+    const resp = await fetch(`/api/picking/search?sapOrder=${encodeURIComponent(sapOrder)}`)
+    if (resp.ok) {
+      const data = await resp.json()
+      setOrderData({ ...data.order, lines: data.lines })
+      setPicking(data.picking)
+
+      if (selectedPicking && data.picking?.sap_order_id === selectedPicking.sap_order_id) {
+        setSelectedPicking(data.picking)
+      }
+    }
+
+    await refreshDashboard()
+  }
+
   useEffect(() => {
     refreshDashboard()
   }, [filters])
 
   const handleUpload = async (
-    ctx: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string },
+    ctx: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; action?: 'create' | 'replace' },
     file: File,
     sapOrderOverride?: string,
   ) => {
@@ -156,7 +179,7 @@ export default function PickingDashboard() {
     const formData = new FormData()
     formData.append('file', file)
 
-    setLoading(true)
+    setUploading(true)
     setFeedback(null)
     try {
       const uploadResp = await fetch(`/api/uploaderS?folder=${encodeURIComponent(folder)}`, {
@@ -170,7 +193,7 @@ export default function PickingDashboard() {
       if (!photoUrl) throw new Error('No se obtuvo URL de la foto')
 
       const resp = await fetch('/api/picking/photo', {
-        method: 'POST',
+        method: ctx.action === 'replace' ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           pickingId: ctx.pickingId,
@@ -182,30 +205,20 @@ export default function PickingDashboard() {
       })
       const data = await resp.json()
       if (!resp.ok) throw new Error(data?.message || 'Error guardando evidencia')
-      setFeedback(`Foto ${ctx.type === 'PICK' ? 'de picking' : 'de embalaje'} guardada`)
-      await fetchSearch()
-      await refreshDashboard()
+      setFeedback(`Foto ${ctx.type === 'PICK' ? 'de picking' : 'de embalaje'} ${ctx.action === 'replace' ? 'actualizada' : 'guardada'}`)
 
-      if (sapOrder) {
-        const refreshed = await fetch(`/api/picking/search?sapOrder=${encodeURIComponent(sapOrder)}`)
-        if (refreshed.ok) {
-          const refreshedData = await refreshed.json()
-          if (refreshedData.picking?.sap_order_id === selectedPicking?.sap_order_id) {
-            setSelectedPicking(refreshedData.picking)
-          }
-        }
-      }
+      await refreshPickingData(sapOrder)
     } catch (error: any) {
       setFeedback(error?.message || 'No se pudo subir la foto')
     } finally {
-      setLoading(false)
+      setUploading(false)
       setUploadContext(null)
     }
   }
 
   const markCompleted = async () => {
     if (!picking?.id) return
-    setLoading(true)
+    setCompleting(true)
     setFeedback(null)
     try {
       const resp = await fetch('/api/picking/status', {
@@ -216,12 +229,94 @@ export default function PickingDashboard() {
       const data = await resp.json()
       if (!resp.ok) throw new Error(data?.message || 'No se pudo completar')
       setPicking(data.picking)
+      if (selectedPicking?.id === picking.id) setSelectedPicking(data.picking)
       await refreshDashboard()
       setFeedback('Pedido marcado como completado')
     } catch (error: any) {
       setFeedback(error?.message || 'No se pudo completar el picking')
     } finally {
-      setLoading(false)
+      setCompleting(false)
+    }
+  }
+
+  const handleDeletePhoto = async (ctx: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string }) => {
+    const sapOrder = picking?.sap_order_id || orderData?.sapOrder || selectedPicking?.sap_order_id
+    const key = `${ctx.type}-${ctx.lineId || ctx.pickingId}`
+    setDeletingPhotoKey(key)
+    setFeedback(null)
+
+    try {
+      const resp = await fetch('/api/picking/photo', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pickingId: ctx.pickingId,
+          pickingLineId: ctx.lineId,
+          photoType: ctx.type,
+          userId: currentUserId,
+        }),
+      })
+
+      const data = await resp.json()
+      if (!resp.ok) throw new Error(data?.message || 'No se pudo eliminar la foto')
+
+      setFeedback('Foto eliminada')
+      await refreshPickingData(sapOrder)
+    } catch (error: any) {
+      setFeedback(error?.message || 'No se pudo eliminar la foto')
+    } finally {
+      setDeletingPhotoKey(null)
+    }
+  }
+
+  const handleDeleteLine = async (lineId: number) => {
+    if (!lineId) return
+    setDeletingLineId(lineId)
+    setFeedback(null)
+
+    try {
+      const resp = await fetch('/api/picking/line', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ lineId }),
+      })
+
+      const data = await resp.json()
+      if (!resp.ok) throw new Error(data?.message || 'No se pudo eliminar la línea')
+
+      setFeedback('Línea eliminada')
+      await refreshPickingData()
+    } catch (error: any) {
+      setFeedback(error?.message || 'No se pudo eliminar la línea')
+    } finally {
+      setDeletingLineId(null)
+    }
+  }
+
+  const handleDeletePicking = async (pickingId?: number) => {
+    if (!pickingId) return
+    setDeletingPickingId(pickingId)
+    setFeedback(null)
+
+    try {
+      const resp = await fetch('/api/picking', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pickingId }),
+      })
+
+      const data = await resp.json()
+      if (!resp.ok) throw new Error(data?.message || 'No se pudo eliminar el picking')
+
+      setFeedback('Picking eliminado')
+      setPicking(null)
+      setOrderData(null)
+      setSelectedPicking(null)
+      await refreshDashboard()
+    } catch (error: any) {
+      setFeedback(error?.message || 'No se pudo eliminar el picking')
+    } finally {
+      setDeletingPickingId(null)
     }
   }
 
@@ -230,6 +325,14 @@ export default function PickingDashboard() {
     if (orderData?.lines) return orderData.lines as SapLine[]
     return []
   }, [picking, orderData])
+
+  const isCompleted = picking?.status === 'COMPLETED'
+  const canComplete = !!(
+    picking &&
+    picking.lines?.length &&
+    picking.lines.every((line) => line.status === 'PACKED') &&
+    picking.packingPhoto?.s3_url,
+  )
 
   if (status === 'loading') {
     return (
@@ -260,13 +363,27 @@ export default function PickingDashboard() {
                   {picking.status}
                 </span>
               )}
+              {picking && !isCompleted && (
+                <button
+                  onClick={() => {
+                    if (window.confirm('¿Eliminar este picking? Se perderán las fotos y líneas asociadas.')) {
+                      void handleDeletePicking(picking.id)
+                    }
+                  }}
+                  disabled={deletingPickingId === picking.id}
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-500/20 text-red-100 border border-red-500/40 hover:bg-red-500/30 disabled:opacity-60"
+                >
+                  {deletingPickingId === picking.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                  Eliminar picking
+                </button>
+              )}
               <button
                 onClick={markCompleted}
-                disabled={!picking || loading}
+                disabled={!canComplete || completing || isCompleted}
                 className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-emerald-500/20 text-emerald-100 border border-emerald-500/40 hover:bg-emerald-500/30 disabled:opacity-50"
               >
-                <PackageCheck className="w-4 h-4" />
-                Completar pedido
+                {completing ? <Loader2 className="w-4 h-4 animate-spin" /> : <PackageCheck className="w-4 h-4" />}
+                {isCompleted ? 'Pedido completado' : 'Completar pedido'}
               </button>
             </div>
           </div>
@@ -336,6 +453,7 @@ export default function PickingDashboard() {
                   const pickPhoto = photos.find((p: any) => p.photo_type === 'PICK')
                   const status = picked?.status || 'PENDING'
                   const lineRef = line.sapLineId || (line as any).sap_order_line_id || line.sku || line.id
+                  const photoKey = `PICK-${picked?.id || line.id}`
 
                   return (
                     <div
@@ -348,9 +466,25 @@ export default function PickingDashboard() {
                           <h4 className="text-lg font-semibold text-white">{line.sku}</h4>
                           <p className="text-slate-300 text-sm line-clamp-2">{line.description}</p>
                         </div>
-                        <span className={`px-2 py-1 rounded-lg text-[11px] border ${statusBadges[status] || statusBadges.PENDING}`}>
-                          {status}
-                        </span>
+                        <div className="flex items-start gap-2">
+                          <span className={`px-2 py-1 rounded-lg text-[11px] border ${statusBadges[status] || statusBadges.PENDING}`}>
+                            {status}
+                          </span>
+                          {picking?.id && !isCompleted && (
+                            <button
+                              onClick={() => {
+                                if (window.confirm('¿Eliminar esta línea y sus fotos?')) {
+                                  void handleDeleteLine(picked?.id || line.id)
+                                }
+                              }}
+                              disabled={deletingLineId === (picked?.id || line.id)}
+                              className="p-2 rounded-lg border border-red-500/40 bg-red-500/10 text-red-100 hover:bg-red-500/20 disabled:opacity-60"
+                              aria-label="Eliminar línea"
+                            >
+                              {deletingLineId === (picked?.id || line.id) ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                            </button>
+                          )}
+                        </div>
                       </div>
                       <p className="text-sm text-slate-200">Cantidad: {line.quantity}</p>
 
@@ -358,16 +492,28 @@ export default function PickingDashboard() {
                         <PhotoUploader
                           label="Foto picking"
                           existingUrl={pickPhoto?.s3_url}
-                          disabled={!picking || loading}
+                          disabled={!picking || isCompleted}
+                          busy={uploading || deletingPhotoKey === photoKey}
                           onUpload={() =>
                             setUploadContext({
                               lineId: picked?.id || line.id,
                               type: 'PICK',
                               lineRef: String(lineRef),
                               sapOrder: picking?.sap_order_id || orderData?.sapOrder,
+                              action: pickPhoto ? 'replace' : 'create',
                             })
                           }
                           onPreview={(url) => setPreviewPhoto({ url, title: `${line.sku} · Picking` })}
+                          onDelete={
+                            pickPhoto && !isCompleted
+                              ? () =>
+                                  handleDeletePhoto({
+                                    lineId: picked?.id || line.id,
+                                    type: 'PICK',
+                                    lineRef: String(lineRef),
+                                  })
+                              : undefined
+                          }
                         />
                       </div>
                     </div>
@@ -387,16 +533,23 @@ export default function PickingDashboard() {
                   <PhotoUploader
                     label="Foto de packing"
                     existingUrl={picking.packingPhoto?.s3_url}
-                    disabled={loading}
+                    disabled={isCompleted}
+                    busy={uploading || deletingPhotoKey === `PACK-${picking.id}`}
                     onUpload={() =>
                       setUploadContext({
                         pickingId: picking.id,
                         type: 'PACK',
                         lineRef: 'packing',
                         sapOrder: picking.sap_order_id || orderData?.sapOrder,
+                        action: picking.packingPhoto?.s3_url ? 'replace' : 'create',
                       })
                     }
                     onPreview={(url) => setPreviewPhoto({ url, title: `${orderData?.sapOrder || picking.sap_order_id} · Packing` })}
+                    onDelete={
+                      picking.packingPhoto?.s3_url && !isCompleted
+                        ? () => handleDeletePhoto({ pickingId: picking.id, type: 'PACK', lineRef: 'packing' })
+                        : undefined
+                    }
                   />
                 </div>
               )}
@@ -488,21 +641,37 @@ export default function PickingDashboard() {
                       <td className="px-4 py-3 text-slate-200">
                         {packed}/{totalLines} líneas embaladas
                       </td>
-                      <td className="px-4 py-3 text-slate-400">
-                        {p.updated_at ? format(new Date(p.updated_at as any), 'dd MMM yyyy HH:mm') : '—'}
-                      </td>
-                      <td className="px-4 py-3">
+                  <td className="px-4 py-3 text-slate-400">
+                    {p.updated_at ? format(new Date(p.updated_at as any), 'dd MMM yyyy HH:mm') : '—'}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <button
+                        onClick={() => setSelectedPicking(p)}
+                        className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/60 border border-white/10 text-slate-100 hover:bg-slate-800"
+                      >
+                        <Camera className="w-4 h-4" />
+                        {isViewOnly ? 'Ver' : 'Editar / aprobar'}
+                      </button>
+                      {p.status !== 'COMPLETED' && (
                         <button
-                          onClick={() => setSelectedPicking(p)}
-                          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/60 border border-white/10 text-slate-100 hover:bg-slate-800"
+                          onClick={() => {
+                            if (window.confirm('¿Eliminar este picking?')) {
+                              void handleDeletePicking(p.id)
+                            }
+                          }}
+                          disabled={deletingPickingId === p.id}
+                          className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-red-600/15 border border-red-500/50 text-red-100 hover:bg-red-600/25 disabled:opacity-60"
                         >
-                          <Camera className="w-4 h-4" />
-                          {isViewOnly ? 'Ver' : 'Editar / aprobar'}
+                          {deletingPickingId === p.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                          Eliminar
                         </button>
-                      </td>
-                    </tr>
-                  )
-                })}
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              )
+            })}
               </tbody>
             </table>
           </div>
@@ -536,6 +705,7 @@ export default function PickingDashboard() {
                   pickingId: cameraCapture.pickingId,
                   type: cameraCapture.type,
                   lineRef: cameraCapture.lineRef,
+                  action: cameraCapture.action,
                 },
                 file,
                 cameraCapture.sapOrder,
@@ -551,6 +721,11 @@ export default function PickingDashboard() {
             onClose={() => setSelectedPicking(null)}
             onOpenUpload={(payload) => setUploadContext(payload)}
             onPreview={(url, title) => setPreviewPhoto({ url, title })}
+            onDeletePhoto={handleDeletePhoto}
+            onDeleteLine={handleDeleteLine}
+            uploading={uploading}
+            deletingPhotoKey={deletingPhotoKey}
+            deletingLineId={deletingLineId}
           />
         )}
       </div>
@@ -569,6 +744,7 @@ export default function PickingDashboard() {
                 pickingId: uploadContext.pickingId,
                 type: uploadContext.type,
                 lineRef: uploadContext.lineRef,
+                action: uploadContext.action,
               },
               file,
               uploadContext.sapOrder,
@@ -591,6 +767,7 @@ export default function PickingDashboard() {
                 pickingId: uploadContext.pickingId,
                 type: uploadContext.type,
                 lineRef: uploadContext.lineRef,
+                action: uploadContext.action,
               },
               file,
               uploadContext.sapOrder,
@@ -608,13 +785,18 @@ function PhotoUploader({
   onUpload,
   onPreview,
   disabled,
+  busy,
+  onDelete,
 }: {
   label: string
   existingUrl?: string
   onUpload: () => void
   onPreview?: (url: string) => void
   disabled?: boolean
+  busy?: boolean
+  onDelete?: () => void
 }) {
+  const isDisabled = disabled || busy
   return (
     <div className="p-3 rounded-2xl border border-white/10 bg-gradient-to-br from-slate-950/80 via-slate-900/80 to-slate-950/60 shadow-inner flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
@@ -654,10 +836,21 @@ function PhotoUploader({
             <button
               type="button"
               onClick={onUpload}
-              className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-sky-700/40 border border-sky-500/40 text-sky-50 hover:bg-sky-700/50"
+              disabled={isDisabled}
+              className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-sky-700/40 border border-sky-500/40 text-sky-50 hover:bg-sky-700/50 disabled:opacity-60"
             >
               <Camera className="w-4 h-4" /> Reemplazar
             </button>
+            {onDelete && (
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={isDisabled}
+                className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-red-600/20 border border-red-500/50 text-red-100 hover:bg-red-600/30 disabled:opacity-60"
+              >
+                <Trash2 className="w-4 h-4" /> Eliminar
+              </button>
+            )}
           </div>
         </div>
       ) : (
@@ -665,7 +858,7 @@ function PhotoUploader({
           <button
             type="button"
             onClick={onUpload}
-            disabled={disabled}
+            disabled={isDisabled}
             className="flex-1 inline-flex items-center justify-between gap-2 text-slate-200 px-3 py-2 rounded-lg bg-slate-900/70 border border-sky-700/40 hover:bg-slate-900 disabled:opacity-40"
           >
             <span className="text-left">Tomar foto</span>
@@ -684,11 +877,11 @@ function PhotoCapturePrompt({
   cameraInputRef,
   onCamera,
 }: {
-  context: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string }
+  context: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string; action?: 'create' | 'replace' }
   onClose: () => void
   galleryInputRef: React.RefObject<HTMLInputElement>
   cameraInputRef: React.RefObject<HTMLInputElement>
-  onCamera: (ctx: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string }) => void
+  onCamera: (ctx: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string; action?: 'create' | 'replace' }) => void
 }) {
   return (
     <div className="fixed inset-0 z-40 bg-black/70 backdrop-blur-sm flex items-center justify-center px-4">
@@ -741,7 +934,7 @@ function CameraCaptureModal({
   onClose,
   onCapture,
 }: {
-  context: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string }
+  context: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string; action?: 'create' | 'replace' }
   onClose: () => void
   onCapture: (file: File) => Promise<void>
 }) {
@@ -852,13 +1045,25 @@ function ExistingPickingModal({
   onClose,
   onOpenUpload,
   onPreview,
+  onDeletePhoto,
+  onDeleteLine,
+  uploading,
+  deletingPhotoKey,
+  deletingLineId,
 }: {
   picking: Picking
   onClose: () => void
-  onOpenUpload: (payload: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string }) => void
+  onOpenUpload: (payload: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string; sapOrder: string; action?: 'create' | 'replace' }) => void
   onPreview: (url: string, title: string) => void
+  onDeletePhoto: (payload: { lineId?: number; pickingId?: number; type: 'PICK' | 'PACK'; lineRef: string }) => Promise<void>
+  onDeleteLine: (lineId: number) => Promise<void>
+  uploading: boolean
+  deletingPhotoKey: string | null
+  deletingLineId: number | null
 }) {
   const packPhoto = picking.packingPhoto
+  const viewOnly = picking.status === 'COMPLETED'
+  const packPhotoKey = `PACK-${picking.id}`
   return (
     <div className="fixed inset-0 z-30 bg-black/70 backdrop-blur-sm flex items-center justify-center px-4">
       <div className="bg-slate-950/95 border border-white/10 rounded-3xl w-full max-w-5xl p-7 shadow-2xl max-h-[90vh] overflow-y-auto">
@@ -888,16 +1093,23 @@ function ExistingPickingModal({
           <PhotoUploader
             label="Foto packing"
             existingUrl={packPhoto?.s3_url}
-            disabled={false}
+            disabled={viewOnly}
+            busy={uploading || deletingPhotoKey === packPhotoKey}
             onUpload={() =>
               onOpenUpload({
                 pickingId: picking.id,
                 type: 'PACK',
                 lineRef: 'packing',
                 sapOrder: picking.sap_order_id || '',
+                action: packPhoto?.s3_url ? 'replace' : 'create',
               })
             }
             onPreview={(url) => onPreview(url, `${picking.sap_order_id} · Packing`)}
+            onDelete={
+              packPhoto?.s3_url && !viewOnly
+                ? () => onDeletePhoto({ pickingId: picking.id, type: 'PACK', lineRef: 'packing' })
+                : undefined
+            }
           />
         </div>
 
@@ -905,6 +1117,7 @@ function ExistingPickingModal({
           {picking.lines?.map((line) => {
             const pickPhoto = line.photos?.find((p) => p.photo_type === 'PICK')
             const lineRef = line.sapLineId || (line as any).sap_order_line_id || line.sku || line.id
+            const photoKey = `PICK-${line.id}`
             return (
               <div key={line.id} className="p-5 rounded-2xl border border-white/10 bg-slate-900/85 space-y-3 shadow-inner">
                 <div className="flex items-start justify-between gap-2">
@@ -913,9 +1126,25 @@ function ExistingPickingModal({
                     <h4 className="text-lg font-semibold text-white">{line.sku}</h4>
                     <p className="text-slate-300 text-sm line-clamp-2">{line.description}</p>
                   </div>
-                  <span className={`px-2 py-1 rounded-lg text-[11px] border ${statusBadges[line.status] || statusBadges.PENDING}`}>
-                    {line.status}
-                  </span>
+                  <div className="flex items-start gap-2">
+                    <span className={`px-2 py-1 rounded-lg text-[11px] border ${statusBadges[line.status] || statusBadges.PENDING}`}>
+                      {line.status}
+                    </span>
+                    {!viewOnly && (
+                      <button
+                        onClick={() => {
+                          if (window.confirm('¿Eliminar esta línea y sus fotos?')) {
+                            void onDeleteLine(line.id)
+                          }
+                        }}
+                        disabled={deletingLineId === line.id}
+                        className="p-2 rounded-lg border border-red-500/40 bg-red-500/10 text-red-100 hover:bg-red-500/20 disabled:opacity-60"
+                        aria-label="Eliminar línea"
+                      >
+                        {deletingLineId === line.id ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 <p className="text-sm text-slate-200">Cantidad: {line.quantity}</p>
@@ -924,16 +1153,23 @@ function ExistingPickingModal({
                   <PhotoUploader
                     label="Foto picking"
                     existingUrl={pickPhoto?.s3_url}
-                    disabled={false}
+                    disabled={viewOnly}
+                    busy={uploading || deletingPhotoKey === photoKey}
                     onUpload={() =>
                       onOpenUpload({
                         lineId: line.id,
                         type: 'PICK',
                         lineRef: String(lineRef),
                         sapOrder: picking.sap_order_id || '',
+                        action: pickPhoto ? 'replace' : 'create',
                       })
                     }
                     onPreview={(url) => onPreview(url, `${line.sku} · Picking`)}
+                    onDelete={
+                      pickPhoto && !viewOnly
+                        ? () => onDeletePhoto({ lineId: line.id, type: 'PICK', lineRef: String(lineRef) })
+                        : undefined
+                    }
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- prevent photo edits when a picking is completed and recalculate statuses after uploads, replacements, or deletes
- allow deleting picking lines and entire pickings before completion with backend safeguards
- improve picking UI with loading states, refreshes, deletion controls, and conditional completion button

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a5fb1e908320ab5a834b6dae98a3)